### PR TITLE
Post food to meal

### DIFF
--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -83,10 +83,10 @@ router.post("/:meal_id/foods/:id", async function(req, res, next) {
   var meal = await Meal.findOne({ where: { id: req.params.meal_id }})
   var food = await Food.findOne({ where: { id: req.params.id }})
 	if (food && meal) {
-		var foodmeal = await FoodMeals.findOne({ where: {FoodId: food.id, MealId: meal.id}})
+	  var foodmeal = await FoodMeals.findOne({ where: {FoodId: food.id, MealId: meal.id}})
 	}
 	else {
-		var foodmeal = null
+	  var foodmeal = null
 	}
 
   if (meal && food && foodmeal === null) {
@@ -104,16 +104,16 @@ router.post("/:meal_id/foods/:id", async function(req, res, next) {
   	});
 	}
 	else if (foodmeal !== null) {
-    res.setHeader('Content-Type', 'application/json');
-    res.status(406).send({ error: 'Food already belongs to this meal' })
+    	  res.setHeader('Content-Type', 'application/json');
+    	  res.status(406).send({ error: 'Food already belongs to this meal' })
 	}
 	else if (!food || !meal) {
-    res.setHeader('Content-Type', 'application/json');
-    res.status(404).send({ error: 'Valid food and meal required' })
+    	  res.setHeader('Content-Type', 'application/json');
+    	  res.status(404).send({ error: 'Valid food and meal required' })
 	}
 	else {
-    res.setHeader('Content-Type', 'application/json');
-    res.status(500).send({ error })
+    	  res.setHeader('Content-Type', 'application/json');
+    	  res.status(500).send({ error })
 	}
 });
 

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -2,6 +2,7 @@ var express = require('express');
 var router = express.Router();
 var Meal = require('../../../models').Meal;
 var Food = require('../../../models').Food;
+var FoodMeals = require('../../../models').FoodMeals;
 
 /* GET all meals */
 router.get("/", function(req, res, next) {
@@ -76,6 +77,44 @@ router.delete('/:meal_id/foods/:id', function(req, res) {
     res.setHeader('Content-Type', 'application/json');
     res.status(500).send({ error })
   });
+});
+
+router.post("/:meal_id/foods/:id", async function(req, res, next) {
+  var meal = await Meal.findOne({ where: { id: req.params.meal_id }})
+  var food = await Food.findOne({ where: { id: req.params.id }})
+	if (food && meal) {
+		var foodmeal = await FoodMeals.findOne({ where: {FoodId: food.id, MealId: meal.id}})
+	}
+	else {
+		var foodmeal = null
+	}
+
+  if (meal && food && foodmeal === null) {
+    FoodMeals.create({
+      FoodId: food.id,
+      MealId: meal.id
+    })
+  	.then(foodMeals => {
+  	  res.setHeader('Content-Type', 'application/json');
+  	  res.status(201).send(JSON.stringify({message: `Successfully added ${food.name} to ${meal.name}`}));
+  		})
+  	.catch(error => {
+  	  res.setHeader('Content-Type', 'application/json');
+  	  res.status(500).send({ error })
+  	});
+	}
+	else if (foodmeal !== null) {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(406).send({ error: 'The food already belongs to this meal' })
+	}
+	else if (!food || !meal) {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(404).send({ error: 'Valid food and meal required' })
+	}
+	else {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(500).send({ error })
+	}
 });
 
 module.exports = router;

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -105,7 +105,7 @@ router.post("/:meal_id/foods/:id", async function(req, res, next) {
 	}
 	else if (foodmeal !== null) {
     res.setHeader('Content-Type', 'application/json');
-    res.status(406).send({ error: 'The food already belongs to this meal' })
+    res.status(406).send({ error: 'Food already belongs to this meal' })
 	}
 	else if (!food || !meal) {
     res.setHeader('Content-Type', 'application/json');

--- a/tests/requests/meals/post_food_to_meal.spec.js
+++ b/tests/requests/meals/post_food_to_meal.spec.js
@@ -1,0 +1,44 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../../app');
+var Meal = require('../../../models').Meal;
+
+describe('post /api/v1/meals/:meal_id/foods/:id path', () => {
+	beforeAll(() => {
+	  shell.exec('npx sequelize db:create')
+	});
+	beforeEach(() => {
+	    shell.exec('npx sequelize db:migrate')
+	    shell.exec('npx sequelize db:seed:all')
+	  });
+	afterEach(() => {
+	  shell.exec('npx sequelize db:migrate:undo:all')
+	});
+
+	
+  test('should return a 201 status for valid food add', async () => {
+    const response = await request(app).post('/api/v1/meals/2/foods/2');
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe('Successfully added Yogurt to Snack');
+  });
+
+  test('should return a 406 status for duplicate food add', async () => {
+    const response = await request(app).post('/api/v1/meals/2/foods/1');
+    expect(response.status).toBe(406);
+    expect(response.body.error).toBe('Food already belongs to this meal');
+  });
+
+  test('should return a 404 status for invalid meal', async () => {
+    const response = await request(app).post('/api/v1/meals/22/foods/1');
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Valid food and meal required');
+  });
+
+  test('should return a 404 status for invalid food', async () => {
+    const response = await request(app).post('/api/v1/meals/2/foods/11');
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Valid food and meal required');
+  });
+});
+
+

--- a/tests/requests/meals/post_food_to_meal.spec.js
+++ b/tests/requests/meals/post_food_to_meal.spec.js
@@ -17,27 +17,27 @@ describe('post /api/v1/meals/:meal_id/foods/:id path', () => {
 
 	
   test('should return a 201 status for valid food add', async () => {
-    const response = await request(app).post('/api/v1/meals/2/foods/2');
-    expect(response.status).toBe(201);
-    expect(response.body.message).toBe('Successfully added Yogurt to Snack');
+	const response = await request(app).post('/api/v1/meals/2/foods/2');
+	expect(response.status).toBe(201);
+	expect(response.body.message).toBe('Successfully added Yogurt to Snack');
   });
 
   test('should return a 406 status for duplicate food add', async () => {
-    const response = await request(app).post('/api/v1/meals/2/foods/1');
-    expect(response.status).toBe(406);
-    expect(response.body.error).toBe('Food already belongs to this meal');
+	const response = await request(app).post('/api/v1/meals/2/foods/1');
+	expect(response.status).toBe(406);
+	expect(response.body.error).toBe('Food already belongs to this meal');
   });
 
   test('should return a 404 status for invalid meal', async () => {
-    const response = await request(app).post('/api/v1/meals/22/foods/1');
-    expect(response.status).toBe(404);
-    expect(response.body.error).toBe('Valid food and meal required');
+	const response = await request(app).post('/api/v1/meals/22/foods/1');
+	expect(response.status).toBe(404);
+	expect(response.body.error).toBe('Valid food and meal required');
   });
 
   test('should return a 404 status for invalid food', async () => {
-    const response = await request(app).post('/api/v1/meals/2/foods/11');
-    expect(response.status).toBe(404);
-    expect(response.body.error).toBe('Valid food and meal required');
+	const response = await request(app).post('/api/v1/meals/2/foods/11');
+	expect(response.status).toBe(404);
+	expect(response.body.error).toBe('Valid food and meal required');
   });
 });
 


### PR DESCRIPTION
## What functionality does this accomplish?
closes #9

**Description:**

This PR adds the post route and spec for adding a food to meal.  
`POST /api/v1/meals/:meal_id/foods/:id`

It returns 404 if the food or the meal doesn't exist.

It returns 406 if the food is already associated with the meal. 

It contains testing for all successful and edge case scenarios. 

## What did you struggle on to complete?

no current blockers

## Current Test Suite:
### Test Coverage Percentage: 100%
- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
* Resource link AND small description of info gathered/learned
[Sequelize Model Documentation](https://sequelize.org/master/manual/models-usage.html)